### PR TITLE
fix(security): clé API requise sur toutes les mutations (V1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,9 +39,11 @@ jobs:
       - name: Deploy to Deno Deploy
         env:
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+          API_ADMIN_KEY: ${{ secrets.API_ADMIN_KEY }}
         run: |
           deployctl deploy \
             --project=api-zone01-rouen \
             --entrypoint=src/server.ts \
             --include=src,deps.ts,config,deno.json,deno.lock,docs/out \
+            --env=API_ADMIN_KEY=$API_ADMIN_KEY \
             --prod

--- a/src/route/route.ts
+++ b/src/route/route.ts
@@ -5,6 +5,7 @@ import {
     API_VERSION,
 } from "../../config/config.ts";
 import {checkToken} from "../utils/token.ts"
+import {requireApiKey} from "../utils/apiKey.ts"
 
 import {getUserInfo, getUsers} from "../api/v1/user.ts";
 import {getPromotionProgress, getPromotionsHandler, getOptionalPromotionProgress} from "../api/v1/promotion.ts";
@@ -74,14 +75,14 @@ async function loadPromotionController() {
         router.get(`/${API_BASE_PATH}/${API_VERSION}/promotions/:eventId/students`, getPromotionProgress)
             .get(`/${API_BASE_PATH}/${API_VERSION}/promotions/:eventId/students/optionals`, getOptionalPromotionProgress)
             .get(`/${API_BASE_PATH}/${API_VERSION}/promotions`, getPromotionsHandler)
-            .post(`/${API_BASE_PATH}/${API_VERSION}/promotions`, createPromotionHandler)
+            .post(`/${API_BASE_PATH}/${API_VERSION}/promotions`, requireApiKey, createPromotionHandler)
             .get(`/${API_BASE_PATH}/${API_VERSION}/promotions/:promoId`, getPromotionByIdHandler)
-            .post(`/${API_BASE_PATH}/${API_VERSION}/promotions/:promoId/archive`, archivePromotionHandler)
+            .post(`/${API_BASE_PATH}/${API_VERSION}/promotions/:promoId/archive`, requireApiKey, archivePromotionHandler)
             .get(`/${API_BASE_PATH}/${API_VERSION}/promo-configs`, getPromoConfigsHandler)
             .get(`/${API_BASE_PATH}/${API_VERSION}/promo-configs/:key`, getPromoConfigHandler)
-            .post(`/${API_BASE_PATH}/${API_VERSION}/promo-configs`, createPromoConfigHandler)
-            .put(`/${API_BASE_PATH}/${API_VERSION}/promo-configs/:key`, updatePromoConfigHandler)
-            .delete(`/${API_BASE_PATH}/${API_VERSION}/promo-configs/:key`, deletePromoConfigHandler);
+            .post(`/${API_BASE_PATH}/${API_VERSION}/promo-configs`, requireApiKey, createPromoConfigHandler)
+            .put(`/${API_BASE_PATH}/${API_VERSION}/promo-configs/:key`, requireApiKey, updatePromoConfigHandler)
+            .delete(`/${API_BASE_PATH}/${API_VERSION}/promo-configs/:key`, requireApiKey, deletePromoConfigHandler);
     } catch (error) {
         console.error('Error loading promotion controller:', error);
     }
@@ -92,9 +93,9 @@ async function loadProjectsController() {
         router.get(`/${API_BASE_PATH}/${API_VERSION}/projects`, getProjectsHandler)
             .get(`/${API_BASE_PATH}/${API_VERSION}/projects/catalog`, getProjectsCatalog)
             .get(`/${API_BASE_PATH}/${API_VERSION}/projects/:id`, getProjectHandler)
-            .post(`/${API_BASE_PATH}/${API_VERSION}/projects`, createProjectHandler)
-            .put(`/${API_BASE_PATH}/${API_VERSION}/projects/:id`, updateProjectHandler)
-            .delete(`/${API_BASE_PATH}/${API_VERSION}/projects/:id`, deleteProjectHandler);
+            .post(`/${API_BASE_PATH}/${API_VERSION}/projects`, requireApiKey, createProjectHandler)
+            .put(`/${API_BASE_PATH}/${API_VERSION}/projects/:id`, requireApiKey, updateProjectHandler)
+            .delete(`/${API_BASE_PATH}/${API_VERSION}/projects/:id`, requireApiKey, deleteProjectHandler);
     } catch (error) {
         console.error('Error loading projects controller:', error);
     }
@@ -113,9 +114,9 @@ async function loadHolidaysController() {
     try {
         router.get(`/${API_BASE_PATH}/${API_VERSION}/holidays`, getHolidaysHandler)
             .get(`/${API_BASE_PATH}/${API_VERSION}/holidays/:id`, getHolidayHandler)
-            .post(`/${API_BASE_PATH}/${API_VERSION}/holidays`, createHolidayHandler)
-            .put(`/${API_BASE_PATH}/${API_VERSION}/holidays/:id`, updateHolidayHandler)
-            .delete(`/${API_BASE_PATH}/${API_VERSION}/holidays/:id`, deleteHolidayHandler);
+            .post(`/${API_BASE_PATH}/${API_VERSION}/holidays`, requireApiKey, createHolidayHandler)
+            .put(`/${API_BASE_PATH}/${API_VERSION}/holidays/:id`, requireApiKey, updateHolidayHandler)
+            .delete(`/${API_BASE_PATH}/${API_VERSION}/holidays/:id`, requireApiKey, deleteHolidayHandler);
     } catch (error) {
         console.error('Error loading holidays controller:', error);
     }
@@ -130,8 +131,8 @@ async function loadDiscordController() {
             .get(`/${API_BASE_PATH}/${API_VERSION}/discord/job-queries`, getJobQueries)
             .get(`/${API_BASE_PATH}/${API_VERSION}/discord-users`, getDiscordUsersHandler)
             .get(`/${API_BASE_PATH}/${API_VERSION}/discord-users/:login`, getDiscordUserHandler)
-            .put(`/${API_BASE_PATH}/${API_VERSION}/discord-users`, upsertDiscordUserHandler)
-            .delete(`/${API_BASE_PATH}/${API_VERSION}/discord-users/:login`, deleteDiscordUserHandler);
+            .put(`/${API_BASE_PATH}/${API_VERSION}/discord-users`, requireApiKey, upsertDiscordUserHandler)
+            .delete(`/${API_BASE_PATH}/${API_VERSION}/discord-users/:login`, requireApiKey, deleteDiscordUserHandler);
     } catch (error) {
         console.error('Error loading discord controller:', error);
     }

--- a/src/utils/apiKey.ts
+++ b/src/utils/apiKey.ts
@@ -1,0 +1,30 @@
+// Middleware d'autorisation pour les MUTATIONS (POST/PUT/DELETE).
+//
+// Les routes de mutation (projets, vacances, promo-configs, promotions,
+// discord-users) n'étaient protégées que par CORS — donc ouvertes à tout
+// client non-navigateur. On exige désormais une clé partagée `API_ADMIN_KEY`,
+// envoyée par l'appelant via l'en-tête `X-Api-Key` (ou `Authorization: Bearer`).
+//
+// Fail-closed : si `API_ADMIN_KEY` n'est pas configurée côté serveur, on refuse
+// (503) — il faut explicitement provisionner la clé avant d'exposer ces routes.
+export const requireApiKey = async (ctx: any, next: any) => {
+    const expected = Deno.env.get("API_ADMIN_KEY");
+
+    if (!expected || expected.trim() === "") {
+        ctx.response.status = 503;
+        ctx.response.body = { error: "API_ADMIN_KEY non configurée côté serveur" };
+        return;
+    }
+
+    const provided =
+        ctx.request.headers.get("X-Api-Key") ??
+        (ctx.request.headers.get("Authorization") ?? "").replace("Bearer ", "");
+
+    if (provided !== expected) {
+        ctx.response.status = 401;
+        ctx.response.body = { error: "Clé API invalide ou manquante" };
+        return;
+    }
+
+    await next();
+};


### PR DESCRIPTION
## V1 — Mutations de l'API publiques

Les routes de mutation (projects, holidays, promo-configs, promotions, discord-users) n'étaient protégées que par **CORS** → ouvertes à tout client non-navigateur.

- Nouveau middleware **`requireApiKey`** (`src/utils/apiKey.ts`), **fail-closed**, exigeant l'en-tête `X-Api-Key` == `API_ADMIN_KEY`.
- Appliqué aux **13 routes** POST/PUT/DELETE. Les GET restent publics.

## ⚠️ Avant de merger/déployer (sinon casse le `/connect` du bot)
1. Définir **`API_ADMIN_KEY`** (même valeur) sur **Deno Deploy** *et* côté **bot**.
2. Déployer le **bot** (PR makcimerrr/bot-discord-zone01) **en même temps** que cette API — le bot envoie désormais la clé sur `PUT /discord-users`.
> Fail-closed : sans `API_ADMIN_KEY`, les mutations renvoient 503.

## Vérif
`deno check` : 0 nouvelle erreur (les erreurs `RouterContext` préexistent sur `main`).
🤖 Generated with [Claude Code](https://claude.com/claude-code)