### PR TITLE
fix(security): paramétrage GraphQL (V5) + verrou GET /discord-users (V7)

### DIFF
--- a/src/api/v1/additional.ts
+++ b/src/api/v1/additional.ts
@@ -13,17 +13,24 @@ export const getAdditionalPromotionProgress = async (ctx: RouterContext) => {
         };
         return;
     }
+    if (!Number.isInteger(Number(eventId))) {
+        ctx.response.status = 400;
+        ctx.response.body = {
+            error: "Requête invalide : 'eventId' doit être un entier.",
+        };
+        return;
+    }
 
     try {
         const client = await getClient();
         const query = `
-        query {
+        query ($eventId: Int!) {
           progress(
             where: {
               _and: [
                 { object: { name: { _in: ${JSON.stringify(additionalProjects.map(p => p.toLowerCase()))} } } },
                 { group: { status: { _in: [finished, audit, setup, working] } } },
-                { event: { id: { _eq: ${eventId} } } }
+                { event: { id: { _eq: $eventId } } }
               ]
             }
           ) {
@@ -55,7 +62,7 @@ export const getAdditionalPromotionProgress = async (ctx: RouterContext) => {
         }
       `;
 
-        const response = await client.run(query);
+        const response = await client.run(query, {eventId: Number(eventId)});
         ctx.response.status = 200;
         ctx.response.body = response;
     } catch (error) {

--- a/src/api/v1/promotion.ts
+++ b/src/api/v1/promotion.ts
@@ -28,16 +28,23 @@ const getPromotionProgress = async (ctx: RouterContext) => {
     };
     return;
   }
+  if (!Number.isInteger(Number(eventId))) {
+    ctx.response.status = 400;
+    ctx.response.body = {
+      error: "Requête invalide : 'eventId' doit être un entier.",
+    };
+    return;
+  }
   try {
     const client = await getClient();
     const query = `
-        query {
+        query ($eventId: Int!) {
           progress(
             where: {
               _and: [
                 { object: { name: { _in: ${JSON.stringify(projects.map((p) => p.toLowerCase()))} } } },
                 { group: { status: { _in: [finished, audit, setup, working] } } },
-                { event: { id: { _eq: ${eventId} } } }
+                { event: { id: { _eq: $eventId } } }
               ]
             }
           ) {
@@ -71,7 +78,7 @@ const getPromotionProgress = async (ctx: RouterContext) => {
         }
       `;
 
-    const response = await client.run(query);
+    const response = await client.run(query, {eventId: Number(eventId)});
     ctx.response.status = 200;
     ctx.response.body = response;
   } catch (error) {
@@ -93,17 +100,24 @@ const getOptionalPromotionProgress = async (ctx: RouterContext) => {
     };
     return;
   }
+  if (!Number.isInteger(Number(eventId))) {
+    ctx.response.status = 400;
+    ctx.response.body = {
+      error: "Requête invalide : 'eventId' doit être un entier.",
+    };
+    return;
+  }
 
   try {
     const client = await getClient();
     const query = `
-        query {
+        query ($eventId: Int!) {
           progress(
             where: {
               _and: [
                 { object: { name: { _in: ${JSON.stringify(optionalProjects.map(p => p.toLowerCase()))} } } },
                 { group: { status: { _in: [finished, audit, setup, working] } } },
-                { event: { id: { _eq: ${eventId} } } }
+                { event: { id: { _eq: $eventId } } }
               ]
             }
           ) {
@@ -137,7 +151,7 @@ const getOptionalPromotionProgress = async (ctx: RouterContext) => {
         }
       `;
 
-    const response = await client.run(query);
+    const response = await client.run(query, {eventId: Number(eventId)});
     ctx.response.status = 200;
     ctx.response.body = response;
   } catch (error) {

--- a/src/api/v1/specialty.ts
+++ b/src/api/v1/specialty.ts
@@ -25,15 +25,22 @@ export const getSpecialtyStudents = async (ctx: RouterContext) => {
         return;
     }
 
+    if (eventId !== null && !Number.isInteger(Number(eventId))) {
+        ctx.response.status = 400;
+        ctx.response.body = {error: "Requête invalide : 'eventId' doit être un entier."};
+        return;
+    }
+
     try {
         const client = await getClient();
 
+        const queryArgs = eventId ? "($eventId: Int!)" : "";
         const eventFilter = eventId
-            ? `{ event: { id: { _eq: ${eventId} } } },`
+            ? `{ event: { id: { _eq: $eventId } } },`
             : "";
 
         const query = `
-        query {
+        query ${queryArgs} {
           progress(
             where: {
               _and: [
@@ -73,7 +80,7 @@ export const getSpecialtyStudents = async (ctx: RouterContext) => {
         }
       `;
 
-        const response = await client.run(query);
+        const response = await client.run(query, eventId ? {eventId: Number(eventId)} : undefined);
         const progressData = response?.progress ?? [];
 
         // Group progress entries by student

--- a/src/api/v1/user.ts
+++ b/src/api/v1/user.ts
@@ -36,8 +36,8 @@ const getUserInfo = async (ctx: RouterContext) => {
     try {
         const client = await getClient();
         const query = `
-        query {
-          user(where: {login: {_eq: "${username}"}}) {
+        query ($username: String!) {
+          user(where: {login: {_eq: $username}}) {
             id
             login
             firstName
@@ -52,7 +52,7 @@ const getUserInfo = async (ctx: RouterContext) => {
           }
         }`;
 
-        const response = await client.run(query);
+        const response = await client.run(query, {username});
         ctx.response.status = 200;
         ctx.response.body = response;
     } catch (error) {

--- a/src/route/route.ts
+++ b/src/route/route.ts
@@ -129,8 +129,8 @@ async function loadDiscordController() {
             .get(`/${API_BASE_PATH}/${API_VERSION}/discord/config/full`, getFullDiscordConfig)
             .get(`/${API_BASE_PATH}/${API_VERSION}/discord/forbidden-schools`, getForbiddenSchools)
             .get(`/${API_BASE_PATH}/${API_VERSION}/discord/job-queries`, getJobQueries)
-            .get(`/${API_BASE_PATH}/${API_VERSION}/discord-users`, getDiscordUsersHandler)
-            .get(`/${API_BASE_PATH}/${API_VERSION}/discord-users/:login`, getDiscordUserHandler)
+            .get(`/${API_BASE_PATH}/${API_VERSION}/discord-users`, requireApiKey, getDiscordUsersHandler)
+            .get(`/${API_BASE_PATH}/${API_VERSION}/discord-users/:login`, requireApiKey, getDiscordUserHandler)
             .put(`/${API_BASE_PATH}/${API_VERSION}/discord-users`, requireApiKey, upsertDiscordUserHandler)
             .delete(`/${API_BASE_PATH}/${API_VERSION}/discord-users/:login`, requireApiKey, deleteDiscordUserHandler);
     } catch (error) {


### PR DESCRIPTION
## Vulns élevées API

### V5 — Injection GraphQL par interpolation
`user.ts`, `promotion.ts` (×2), `additional.ts`, `specialty.ts` interpolaient `username`/`eventId` dans la chaîne GraphQL.
→ **Variables GraphQL paramétrées** (`$username: String!`, `$eventId: Int!`) + validation `Number.isInteger(eventId)` (400 sinon). Forme des réponses inchangée.

### V7 — login↔Discord public
`GET /discord-users` et `/discord-users/:login` exposaient toute la table login↔discordId sans auth → ajout de `requireApiKey`.

### V8 — secrets .env
`.env` déjà gitignoré (aucun changement code) ; rotation + env Deno Deploy = opérationnel.

> ⚠️ **À vérifier au merge** : le type `$eventId: Int!` doit matcher le schéma Hasura (`event.id`). Tester `/api/v1/promotions/<eventId>/students` juste après déploiement ; si erreur de type, passer `Int!`→`bigint!`. `deno check` : 0 nouvelle erreur (22 préexistantes RouterContext).
🤖 Generated with [Claude Code](https://claude.com/claude-code)